### PR TITLE
Support websockets for fly hijack

### DIFF
--- a/templates/concourse-nginx-config.j2
+++ b/templates/concourse-nginx-config.j2
@@ -5,6 +5,8 @@ server {
   location / {
      client_max_body_size 20m;
      client_body_timeout  300s;
+     proxy_set_header Upgrade $http_upgrade;
+     proxy_set_header Connection "upgrade";
      proxy_set_header Host $host;
      proxy_pass http://localhost:8080;
   }


### PR DESCRIPTION
This adds the necessary nginx configuration to support websockets which are used for the `fly hijack` command.
